### PR TITLE
Change context dir for docker build

### DIFF
--- a/src/org/caf/Build.groovy
+++ b/src/org/caf/Build.groovy
@@ -158,7 +158,7 @@ def dockerBuild(osConfig, buildType, settings, index) {
         def varName = res.group(1)
         def varType = res.group(2)
         def value = res.group(3)
-        init << """set($varName "$value" CACHE $varType "")\n"""
+        init << """set($varName "$value" CACHE $varType "" FORCE)\n"""
     }
     init << """set(CAF_BUILD_INFO_FILE_PATH "$baseDir/build-${index}.info" CACHE FILEPATH "")\n""" \
          << """set(CMAKE_INSTALL_PREFIX "$installDir" CACHE PATH "")\n""" \

--- a/src/org/caf/Build.groovy
+++ b/src/org/caf/Build.groovy
@@ -173,7 +173,7 @@ def dockerBuild(osConfig, buildType, settings, index) {
     def numCores = settings['numCores'] ?: 1
     def extraEnv = numCores > 1 ? ["CAF_NUM_CORES=$numCores"] : []
     withEnv(settings['env'] + extraEnv) {
-        def image = docker.build(imageName, "sources/.ci/${imageName}")
+        def image = docker.build(imageName, "-f .ci/${imageName}/Dockerfile ${sourceDir}")
         image.inside("--cap-add SYS_PTRACE") {
             settings['tags'].each {
                 if (it != 'docker')

--- a/src/org/caf/Build.groovy
+++ b/src/org/caf/Build.groovy
@@ -173,7 +173,7 @@ def dockerBuild(osConfig, buildType, settings, index) {
     def numCores = settings['numCores'] ?: 1
     def extraEnv = numCores > 1 ? ["CAF_NUM_CORES=$numCores"] : []
     withEnv(settings['env'] + extraEnv) {
-        def image = docker.build(imageName, "-f .ci/${imageName}/Dockerfile ${sourceDir}")
+        def image = docker.build(imageName, "-f ${sourceDir}/.ci/${imageName}/Dockerfile ${sourceDir}")
         image.inside("--cap-add SYS_PTRACE") {
             settings['tags'].each {
                 if (it != 'docker')


### PR DESCRIPTION
Changes the context directory for docker build, so we have access to repository specific files like `robot/dependencies.txt`. 
According to the Jenkins documentation, the command would be:
`-f .ci/image/Dockerfile sources`
but when I'm running `docker build` in the command line, the correct way would be:
`-f sources/.ci/image/Dockerfile sources`
So I'm commiting the first version, but take it with a grain of salt. 